### PR TITLE
Update Package Management URLs For Github Migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "gaap-analytics": "^3.1.0",
-        "govuk-frontend": "^4.7.0",
-        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
+        "govuk-frontend": "^4.9.0",
+        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
       }
     },
     "node_modules/gaap-analytics": {
@@ -21,16 +21,17 @@
       "integrity": "sha512-9G7Hwy/D2bjFymOQIptNArrTDAgGjssAv+L6SvbAJinDOSzeX9zUc46PnDVA5WPHHUC5+er4y9+o/nYbubwPoA=="
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
+      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
     },
     "node_modules/govwifi-shared-frontend": {
       "version": "0.6.8",
-      "resolved": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
+      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
       "integrity": "sha512-T+v5yq2oDOhqKfGUCxsiLmvU3mBrgFHGUo6x+D6+66KOLTj9YEWBgQoh/xl5W0qc3IKMyBONB2FhzEXttslgkA==",
       "license": "MIT",
       "dependencies": {
@@ -57,12 +58,12 @@
       "integrity": "sha512-9G7Hwy/D2bjFymOQIptNArrTDAgGjssAv+L6SvbAJinDOSzeX9zUc46PnDVA5WPHHUC5+er4y9+o/nYbubwPoA=="
     },
     "govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
+      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg=="
     },
     "govwifi-shared-frontend": {
-      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
+      "version": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
       "integrity": "sha512-T+v5yq2oDOhqKfGUCxsiLmvU3mBrgFHGUo6x+D6+66KOLTj9YEWBgQoh/xl5W0qc3IKMyBONB2FhzEXttslgkA==",
       "requires": {
         "js-cookie": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -5,18 +5,18 @@
   "description": "This is an example product page for use by GaaP products.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alphagov/govwifi-product-page.git"
+    "url": "git+https://github.com/GovWifi/govwifi-product-page.git"
   },
   "author": "Government Digital Service developers",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/alphagov/govwifi-product-page/issues"
+    "url": "https://github.com/GovWifi/govwifi-product-page/issues"
   },
-  "homepage": "https://github.com/alphagov/govwifi-product-page#readme",
+  "homepage": "https://github.com/GovWifi/govwifi-product-page#readme",
   "dependencies": {
     "gaap-analytics": "^3.1.0",
-    "govuk-frontend": "^4.7.0",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
+    "govuk-frontend": "^4.9.0",
+    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What
Update Package Management URLs For Github Migration

### Why
We are migrating our github organisation, due to changes at GDS.

Link to Jira card (if applicable):  https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1851
