### PR TITLE
Text changes to Get help connecting page

### DIFF
--- a/source/get-help-connecting.html.erb
+++ b/source/get-help-connecting.html.erb
@@ -32,7 +32,7 @@ description: Get help with any problems you have connecting to GovWifi.
 
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            <%= link_to "sign up by Email", "connect-to-govwifi", class: "govuk-link" =%> if you  have a public sector email address
+            <%= link_to "sign up by email", "connect-to-govwifi", class: "govuk-link" =%> if you  have a public sector email address
           </li>
           <li>
             <%= link_to "ask someone with a public sector email address to sign you up", "ask-staff-member", class: "govuk-link" =%>
@@ -48,17 +48,17 @@ description: Get help with any problems you have connecting to GovWifi.
         <ul class="govuk-list govuk-list--bullet">
 
             <li>
-              make sure you’re entering your username correctly - it’s in the format ‘aabbcc’ - it’s <strong>not</strong> your government email address
+              make sure you’re entering your username correctly - your username is in the format aabbcc - it's not your government email address
             </li>
             <li>
-              make sure you’re entering your password correctly - it’s case sensitive and in the format ‘ThreeRandomWords’ with <strong>NO</strong> spaces
+              make sure you’re entering your password correctly - it’s case sensitive and in the format ThreeRandomWords with no spaces
             </li>
             <li>
               follow the instructions for the type of device you’re using - there are instructions for
               <%= partial 'shared/product/_links' %>
             </li>
             <li>
-              if you’re still having connection problems this may be due to the local network or your device - you will need to contact the IT support provider for your organisation and/or the building you are in
+              if you’re still having connection problems this may be due to the local network or your device - contact the IT support provider for your organisation and / or the building you are in
             </li>
 
         </ul>
@@ -73,16 +73,16 @@ description: Get help with any problems you have connecting to GovWifi.
             check you’re using the correct details by sending a blank email from your public sector email address to <a class="govuk-link" href="mailto:signup@wifi.service.gov.uk">signup@wifi.service.gov.uk</a> or texting ‘Go’ to 07537 417 417
           </li>
           <li>
-            make sure you’re entering your username correctly - it’s in the format ‘aabbcc’ - it’s <strong>not</strong> your government email address
+            make sure you’re entering your username correctly - your username is in the format aabbcc - it's not your government email address
           </li>
           <li>
-            make sure you’re entering your password correctly - it’s case sensitive and in the format ‘ThreeRandomWords’ with <strong>NO</strong> spaces
+            make sure you’re entering your password correctly - it’s case sensitive and in the format ThreeRandomWords with no spaces
           </li>
           <li>
-            try 'forgetting' the network in your device wifi settings and then reconnect to the GovWifi network
+            try forgetting the network in your device wifi settings and then reconnect to the GovWifi network
           </li>
           <li>
-            if you’re still having connection problems this may be due to the local network or your device - you will need to contact the IT support provider for your organisation and/or the building you are in
+            if you’re still having connection problems this may be due to the local network or your device - contact the IT support provider for your organisation and / or the building you are in
           </li>
 
         </ul>


### PR DESCRIPTION

### What
Text changes to Get help connecting page to follow GDS style guide. Bold removed from text elements that are not instructional interface references. Inverted commas removed from text elements that are not non-instructional interface references.

### Why
Makes the page consistent with GDS style guide and with other GDS technical and product documentation.

