### PR TITLE
GW-1876: Strip out any mention of heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Staticfile.auth
 # build-time copied assets
 source/assets
 source/javascripts/dist
+
+.idea/*

--- a/app.json
+++ b/app.json
@@ -1,13 +1,5 @@
 {
   "name": "GovWifi Product Page",
-  "buildpacks": [
-    {
-      "url": "heroku/nodejs"
-    },
-    {
-      "url": "heroku/ruby"
-    }
-  ],
   "scripts": {
     "postdeploy": "npm install"
   }


### PR DESCRIPTION
### What
Remove Heroku reference

### Why
Keeping deprecated or irrelevant code in codebase is bad practice, causes mental overhead and can potentially cause security vulnerabilities.

Link to Jira card (if applicable): 
[GW-1876](https://technologyprogramme.atlassian.net/browse/GW-1876)
