### PR TITLE
Updated MoU version to 2.5

### DIFF
--- a/source/memorandum-of-understanding.html.erb
+++ b/source/memorandum-of-understanding.html.erb
@@ -49,6 +49,7 @@ description: Agreement between GovWifi and organisations offering GovWifi.
         <p class="govuk-body">1.5.b. the provisions of this Agreement and the provisions of any document referred to or referenced herein, the provisions of this Agreement shall prevail.</p>
         <p class="govuk-body">2. Commencement and Term</p>
         <p class="govuk-body"> 2.1. This Agreement commences upon signature by the Cabinet Office and the Organisation, and will remain in force until the GovWifi Authentication Service terminates, unless terminated early, in accordance with Clause 13.</p>     
+        <p class="govuk-body">2.2. The Organisation agrees to comply with the required aspects of the operational procedures and onboarding guidance. Compliance with these documents is a condition of continued participation in the GovWifi service.</p>
         <p class="govuk-body">3. Principles, Representatives and Governance</p>
         <p class="govuk-body"> 3.1. The Cabinet Office and Organisation:</p>
         <p class="govuk-body"> 3.1.a. are committed to a collaborative approach, and will operate the arrangements under this Agreement in recognition of their respective contributions and responsibilities;</p>
@@ -312,11 +313,11 @@ description: Agreement between GovWifi and organisations offering GovWifi.
             </tr>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">Version</th>
-              <td class="govuk-table__cell">2.4</td>
+              <td class="govuk-table__cell">2.5</td>
             </tr>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">Version date</th>
-              <td class="govuk-table__cell">27.03.25</td>
+              <td class="govuk-table__cell">19.08.25</td>
             </tr>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">Next review date</th>
@@ -436,6 +437,11 @@ description: Agreement between GovWifi and organisations offering GovWifi.
               <td class="govuk-table__cell">2.4</td>
               <td class="govuk-table__cell">25.03.25</td>
               <td class="govuk-table__cell">Point 8.9 has been made reciprocal to align with point 8.8, ensuring both parties are equally obligated to provide information in phases, particularly during a Data Loss Event. We've removed Section 8.14. from the MoU to better align with our role as independent data controllers.</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">2.5</td>
+              <td class="govuk-table__cell">19.08.25</td>
+              <td class="govuk-table__cell">Point 2.2 has been added to include the organisation's agreement to comply with the operational procedures and onboarding guidance. Also clarifies that adherence to these documents is a condition for continued participation in the GovWifi service.</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
### What
The MoU needs to be updated with the new content: 

### Why
to ensure the team has more leverage to enforce admin compliance with onboarding and on-going requirements 

to improve the quality of the GovWifi service

### Link to JIRA card (if applicable):
[GW-2410](https://technologyprogramme.atlassian.net/browse/GW-2410)
